### PR TITLE
Prepare xpj conf for using .nimp.conf instead of baseNimp.conf

### DIFF
--- a/nimp/unreal.py
+++ b/nimp/unreal.py
@@ -47,13 +47,18 @@ def load_config(env):
     unreal_base_paths = [
         'UnrealEngine',
         'UE4',
-        '',
+        '.',
     ]
-    for unreal_path in unreal_base_paths:
-        unreal_dir = nimp.system.find_dir_containing_file(os.path.join(unreal_path, unreal_file))
-        if unreal_dir:
-            unreal_dir = os.path.join(unreal_dir, unreal_path)
-            break
+    for base in unreal_base_paths:
+        path_to_base = nimp.system.find_dir_containing_file(os.path.join(base, unreal_file))
+        if not path_to_base:
+            continue
+        # Sanity check: if `base` indicates a monorepo setup, check that it is really one
+        if base != '.' and not (os.path.isfile(os.path.join(path_to_base, '.baseNimp.conf'))
+                                or os.path.isfile(os.path.join(path_to_base, '.nimp.conf'))):
+            continue
+        unreal_dir = os.path.join(path_to_base, base)
+        break
 
     if not unreal_dir:
         env.is_unreal = env.is_ue4 = env.is_ue5 = False


### PR DESCRIPTION


Rework how we load nimp conf files:

- Set is_unreal if .nimp conf file is detected in unreal base path
- Load legacy generic nimp conf first (if no unreal detected, or unreal <= 4.24)
- Load monorepo conf if monorepo unreal is detected
- Monorepo conf consists of base xpj .nimp.conf, overridable by specific uproject conf
- Temporarily maintain deprecated xpj .baseNimp.conf (so we have time to replace them by .nimp.conf files)
