### PR TITLE
U/lca/profling additions

### DIFF
--- a/nimp/environment.py
+++ b/nimp/environment.py
@@ -35,6 +35,7 @@ import glob
 import glob2
 
 import nimp.command
+from nimp.exceptions import NimpCommandFailed
 import nimp.summary
 import nimp.sys.platform
 import nimp.system
@@ -203,7 +204,11 @@ class Environment:
                 try:
                     with nimp.utils.profiling.nimp_profile(self):
                         success = self.command.run(self)
+                        if not success:
+                            raise NimpCommandFailed("Nimp command failed.")
                 #pylint: disable=broad-except
+                except NimpCommandFailed:
+                    pass
                 except Exception as exception:
                     logging.exception(exception)
 

--- a/nimp/environment.py
+++ b/nimp/environment.py
@@ -74,6 +74,7 @@ class Environment:
         prog_description = 'Script utilities to ship games, mostly Unreal Engine based ones.'
         parser = argparse.ArgumentParser(description=prog_description, parents=[parent_parser])
         log_group = parser.add_argument_group("Logging")
+        profiling_group = parser.add_argument_group("Profiling")
 
         log_group.add_argument('-s',
                                '--summary',
@@ -98,6 +99,10 @@ class Environment:
                                '--verbose',
                                help='Enable verbose mode',
                                action='store_true')
+
+        profiling_group.add_argument('--nimp-profiling',
+                                     help='Profile nimp command',
+                                     action='store_true')
 
         nimp.command.add_commands_subparser(self.command_list, parser, self)
 
@@ -127,9 +132,6 @@ class Environment:
                                    metavar='<project branch>',
                                    help='Select a project branch to work with',
                                    type=str)
-        parent_parser.add_argument('--nimp-profiling',
-                                   help='Profile nimp command',
-                                   action='store_true')
         parent_args, unkown_args  = parent_parser.parse_known_args(sys.argv[1:])
 
         # verify that uproject seems somewhat legit
@@ -167,7 +169,6 @@ class Environment:
         # TODO: remove this crappy hacks
         arguments.branch = self.branch if hasattr(self, 'branch') and arguments.branch is None else arguments.branch
         arguments.uproject = self.uproject if hasattr(self, 'uproject') else arguments.uproject
-        arguments.nimp_profiling = self.nimp_profiling if hasattr(self, 'nimp_profiling') else arguments.nimp_profiling
         self.parser = arguments
         for key, value in vars(arguments).items():
             setattr(self, key, value)

--- a/nimp/exceptions.py
+++ b/nimp/exceptions.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Dontnod Entertainment
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+''' Nimp custom excetpions  '''
+
+class NimpCommandFailed(Exception):
+    """ Catched process failure of a nimp command """
+    def __init__(self, *args, **kwargs):
+        pass


### PR DESCRIPTION
Profiling: move profiling arg parse param into its own category

Exceptions: introduce NimpCommandFailed exception

For now it's a convenient way to silently throw a specific exception for any profiling context manager to catch.