### PR TITLE
command: Make dry-run a common argument

### DIFF
--- a/nimp/base_commands/download_fileset.py
+++ b/nimp/base_commands/download_fileset.py
@@ -37,8 +37,7 @@ class DownloadFileset(nimp.command.Command):
 
 
     def configure_arguments(self, env, parser):
-        nimp.command.add_common_arguments(parser, 'free_parameters')
-        parser.add_argument('-n', '--dry-run', action = 'store_true', help = 'perform a test run, without writing changes')
+        nimp.command.add_common_arguments(parser, 'dry_run', 'free_parameters')
         parser.add_argument('--revision', metavar = '<revision>', help = 'find a revision equal to this one')
         parser.add_argument('--max-revision', metavar = '<revision>', help = 'find a revision older or equal to this one')
         parser.add_argument('--min-revision', metavar = '<revision>', help = 'find a revision newer or equal to this one')

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -145,12 +145,11 @@ class Package(nimp.command.Command):
     ''' Packages an unreal project for release '''
 
     def configure_arguments(self, env, parser):
-        nimp.command.add_common_arguments(parser, 'configuration', 'platform', 'free_parameters')
+        nimp.command.add_common_arguments(parser, 'dry_run', 'configuration', 'platform', 'free_parameters')
 
         all_steps = [ 'cook', 'stage', 'package', 'verify' ]
         default_steps = [ 'cook', 'stage', 'package' ]
 
-        parser.add_argument('-n', '--dry-run', action = 'store_true', help = 'perform a test run, without writing changes')
         parser.add_argument('--steps', nargs = '+', choices = all_steps, default = default_steps, metavar = '<step>',
                             help = 'select the steps to execute\n(%s)' % ', '.join(all_steps))
         parser.add_argument('--variant', metavar = '<variant>', help = 'set the configuration variant to use')

--- a/nimp/base_commands/run.py
+++ b/nimp/base_commands/run.py
@@ -55,13 +55,11 @@ class RunCommand(nimp.command.Command):
         super(RunCommand, self).__init__()
 
     def configure_arguments(self, env, parser):
+        nimp.command.add_common_arguments(parser, 'dry_run')
         parser.add_argument('parameters',
                             help='command to run',
                             metavar='<command> [<argument>...]',
                             nargs=argparse.REMAINDER)
-        parser.add_argument('-n', '--dry-run',
-                            action = 'store_true',
-                            help = 'perform a test run, without writing changes')
         return True
 
     def is_available(self, env):

--- a/nimp/base_commands/symbol_server.py
+++ b/nimp/base_commands/symbol_server.py
@@ -78,7 +78,7 @@ class _Update(nimp.command.Command):
 
 
     def configure_arguments(self, env, parser):
-        parser.add_argument('-n', '--dry-run', action = "store_true", help = "perform the command as a simulation")
+        nimp.command.add_common_arguments(parser, 'dry_run')
         return True
 
 
@@ -106,7 +106,7 @@ class _Clean(nimp.command.Command):
 
 
     def configure_arguments(self, env, parser):
-        parser.add_argument('-n', '--dry-run', action = "store_true", help = "perform the command as a simulation")
+        nimp.command.add_common_arguments(parser, 'dry_run')
         return True
 
 

--- a/nimp/base_commands/update_symbol_server.py
+++ b/nimp/base_commands/update_symbol_server.py
@@ -56,10 +56,9 @@ class UpdateSymbolServer(nimp.command.Command):
 
 
     def configure_arguments(self, env, parser):
-        nimp.command.add_common_arguments(parser, 'free_parameters')
+        nimp.command.add_common_arguments(parser, 'dry_run', 'free_parameters')
         parser.add_argument('--symbol-type', required = True, metavar = '<type>', help = 'Set the type of symbols to upload')
         parser.add_argument('--platform', metavar = '<platform>', help = 'Set the platform to upload symbols for')
-        parser.add_argument('-n', '--dry-run', action = "store_true", help = "Do a test run without actually uploading files")
         return True
 
 

--- a/nimp/base_commands/upload.py
+++ b/nimp/base_commands/upload.py
@@ -41,10 +41,10 @@ class _Symbols(nimp.command.Command):
 
     def configure_arguments(self, env, parser):
         nimp.command.add_common_arguments(parser,
+                                          'dry_run'
                                           'platform',
                                           'target',
                                           'revision')
-        parser.add_argument('-n', '--dry-run', action = 'store_true', help = 'perform a test run, without writing changes')
         parser.add_argument('-l',
                             '--configurations',
                             help    = 'Configurations and targets to upload',

--- a/nimp/base_commands/upload_fileset.py
+++ b/nimp/base_commands/upload_fileset.py
@@ -45,8 +45,7 @@ class UploadFileset(nimp.command.Command):
     ''' Uploads a fileset to the artifact repository '''
 
     def configure_arguments(self, env, parser):
-        nimp.command.add_common_arguments(parser, 'revision', 'free_parameters')
-        parser.add_argument('-n', '--dry-run', action = 'store_true', help = 'perform a test run, without writing changes')
+        nimp.command.add_common_arguments(parser, 'dry_run', 'revision', 'free_parameters')
         parser.add_argument('--archive', action = 'store_true', help = 'upload the files as a zip archive')
         parser.add_argument('--compress', action = 'store_true', help = 'if uploading as an archive, compress it')
         parser.add_argument('--torrent', action = 'store_true', help = 'create a torrent for the uploaded fileset')

--- a/nimp/command.py
+++ b/nimp/command.py
@@ -85,6 +85,10 @@ def add_common_arguments(parser, *arg_ids):
                                 metavar = '<key>=<value>',
                                 nargs   = '*',
                                 default = [])
+        elif arg_id == 'dry_run':
+            parser.add_argument('-n', '--dry-run',
+                                action = 'store_true',
+                                help = 'perform a dry run')
         else:
             assert False, 'Unknown argument type'
 


### PR DESCRIPTION
dry-run is a pretty common argument for CLI (as we can see the use in a lot of them here).
Adding as a common_argument will simplify adding it to new commands.