### PR TITLE
Allow using environment as default for arguments

### DIFF
--- a/nimp/command.py
+++ b/nimp/command.py
@@ -188,7 +188,8 @@ def add_commands_subparser(commands, parser, env, required = False):
         command_to_run = command_it
         if not enabled:
             command_to_run = DisabledCommand(reason)
-        env.set_parser_defaults(command_parser)
+        if env.default_to_config:
+            env.set_parser_defaults(command_parser)
         command_parser.set_defaults(command = command_to_run)
 
 class CommandGroup(Command):

--- a/nimp/environment.py
+++ b/nimp/environment.py
@@ -146,8 +146,15 @@ class Environment:
                                    metavar='<config file>',
                                    help='Custom nimp configuration file',
                                    type=str)
+        parent_parser.add_argument('--default-to-config',
+                                   action='store_true',
+                                   default=False,
+                                   help='If enabled, missing arguments will be read from the configuration files')
         self.set_parser_defaults(parent_parser)
         parent_args, unkown_args  = parent_parser.parse_known_args(sys.argv[1:])
+
+        # Set this early so we can use it from command.add_commands_subparser
+        self.default_to_config = parent_args.default_to_config
 
         # verify that uproject seems somewhat legit
         self.validate_uproject(parent_args.uproject)
@@ -184,7 +191,8 @@ class Environment:
         # Loads argument parser, parses argv with it and adds command line parameters
         # as properties of the environment
         parser = self.load_argument_parser(parent_parser)
-        self.set_parser_defaults(parser)
+        if self.default_to_config:
+            self.set_parser_defaults(parser)
         arguments, unknown = parser.parse_known_args(argv[1:])
 
         # TODO: remove this crappy hacks


### PR DESCRIPTION
+ Add `--user-config` argument for passing an additional `.conf` file