### PR TITLE
P4: Add support for json output

### DIFF
--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -376,14 +376,15 @@ class P4:
 
         return True
 
-    def submit_default_changelist(self, description=None, dry_run=False):
+    def submit_default_changelist(self, description=None, revert_unchanged=False, dry_run=False):
         ''' Submits given changelist '''
-        assert description is not None
         logging.info("Submitting default changelist...")
-        command = self._get_p4_command('submit', '-f', 'revertunchanged')
+        command = self._get_p4_command('submit', '-f')
+        if revert_unchanged:
+            command.append('revertunchanged')
         # descriptions could be too long for perforce limitations
         command_length = len(' '.join(command))
-        perforce_cmd_max_characters_limit = 4096
+        perforce_cmd_max_characters_limit = 8191
         if description:
             d_flag = 4  # accounts for ' -d ' string
             description_max_characters_limit = perforce_cmd_max_characters_limit - command_length - d_flag

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -418,7 +418,8 @@ class P4:
         for cl_number in cl_numbers:
             for filename, action in self._parse_command_output(["fstat", "-e", cl_number , root],
                                                                r"^\.\.\. depotFile(.*)$",
-                                                               r"^\.\.\. headAction(.*)"):
+                                                               r"^\.\.\. headAction(.*)",
+                                                               hide_output=True):
                 filename = os.path.normpath(filename) if filename is not None else ''
                 yield filename, action
 

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -270,12 +270,8 @@ class P4:
 
     def print(self, p4_print_command_args):
         ''' wrapper for p4 print command '''
-        output = self._run('print', p4_print_command_args, use_json_format=True)
-        return self.parse_json_output_for_data(output)
-
-    @staticmethod
-    def parse_json_output_for_data(output):
         data = ''
+        output = self._run('print', p4_print_command_args, use_json_format=True)
         output = [json_element for json_element in output.splitlines() if json_element]
         for output_chunk in output:
             output_chunk = json.loads(output_chunk)

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -391,7 +391,7 @@ class P4:
             _, _, error = nimp.sys.process.call(command, capture_output=True)
 
             if error is not None and error != "":
-                logging.error("%s", error)
+                logging.error("%s", error.strip())
                 return False
 
             return True

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -268,7 +268,10 @@ class P4:
 
     def get_file_workspace_current_revision(self, file):
         ''' Returns the file revision currently synced in the workspace '''
-        revision, = next(self._parse_command_output(['have', file], r'\.\.\. haveRev (\d+)'))
+        try:
+            revision, = next(self._parse_command_output(['have', file], r'\.\.\. haveRev (\d+)'))
+        except StopIteration as e:
+            revision = None
         return revision
 
     def print_file_by_revision(self, file, revision_number):

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -416,7 +416,9 @@ class P4:
             matches = re.findall(pattern, cl_spec)
         assert len(matches) == 1
         initial_desc, following_field = matches[0]
-        return re.sub(pattern, f'{spec_field}:{os.linesep}\t{field_content}{os.linesep}{os.linesep}{following_field}', cl_spec)
+        return cl_spec.replace(initial_desc, field_content)
+        # Replace desc rather than re.sub to preserve utf8 chars like \x7A\x3A
+        # return re.sub(pattern, rf'{spec_field}:{os.linesep}\t{field_content}{os.linesep}{os.linesep}{following_field}', cl_spec)
 
     def submit(self, cl_number=None, description=None):
         ''' submit from default if no cl_number is provided
@@ -426,8 +428,8 @@ class P4:
 
         if description is not None:
             cl_spec = self._get_cl_spec(cl_number=cl_number)
-            cl_spec = self._update_cl_spec_field(cl_spec, SpecField.description,
-                                                 "\n\t".join(line for line in description.splitlines()))
+            tabbed_description = "\n\t".join(line for line in description.splitlines())
+            cl_spec = self._update_cl_spec_field(cl_spec, SpecField.description, tabbed_description)
             cl_number, status = self._set_cl_spec(cl_spec)
 
         return self._submit(cl_number)

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -229,18 +229,18 @@ class P4:
 
         return ret
 
-    def reconcile_workspace(self, cl_number=None, workspace_path_to_reconcile=None, dry_run=False):
+    def reconcile_workspace(self, *paths_to_reconcile, cl_number=None, dry_run=False):
         ''' Reconciles given workspace '''
         p4_reconcile_args = ['reconcile', '-f', '-e', '-a', '-d']
         if dry_run:
             p4_reconcile_args.append('-n')
         if cl_number:
             p4_reconcile_args.extend(['-c', cl_number])
-        if workspace_path_to_reconcile:
-            if os.path.isdir(workspace_path_to_reconcile) or workspace_path_to_reconcile.endswith(('/', '\\')):
-                workspace_path_to_reconcile = os.path.join(workspace_path_to_reconcile, '...')
-            workspace_path_to_reconcile = nimp.system.sanitize_path(workspace_path_to_reconcile)
-            p4_reconcile_args.append(workspace_path_to_reconcile)
+        for path_to_reconcile in paths_to_reconcile:
+            if not path_to_reconcile.endswith('...'):
+                if os.path.isdir(path_to_reconcile) or path_to_reconcile.endswith(('/', '\\')):
+                    path_to_reconcile = os.path.join(path_to_reconcile, '...')
+            p4_reconcile_args.append(path_to_reconcile)
 
         return self._run(*p4_reconcile_args) is None
 

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -274,9 +274,9 @@ class P4:
             revision = None
         return revision
 
-    def print_file_by_revision(self, file, revision_number):
-        ''' Prints the file revision for a given revision number '''
-        output = self._run('print', f'{file}#{revision_number}', use_json_format=True)
+    def print(self, p4_print_command_args):
+        ''' wrapper for p4 print command '''
+        output = self._run('print', f'{p4_print_command_args}', use_json_format=True)
         return self.parse_json_output_for_data(output)
 
     @staticmethod

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -452,11 +452,12 @@ class P4:
         command += list(args)
         return command
 
-    def _run(self, *args, stdin=None, use_json_format=False):
+    def _run(self, *args, stdin=None, hide_output=False, use_json_format=False):
         command = self._get_p4_command(*args, use_json_format=use_json_format)
 
         for _ in range(5):
-            result, output, error = nimp.sys.process.call(command, stdin=stdin, encoding='cp437', capture_output=True)
+            result, output, error = nimp.sys.process.call(
+                command, stdin=stdin, encoding='cp437', capture_output=True, hide_output=hide_output)
 
             if 'Operation took too long ' in error:
                 continue
@@ -473,8 +474,8 @@ class P4:
 
             return output
 
-    def _parse_command_output(self, command, *patterns, stdin = None):
-        output = self._run(*command, stdin = stdin)
+    def _parse_command_output(self, command, *patterns, stdin = None, hide_output = False):
+        output = self._run(*command, stdin = stdin, hide_output = hide_output)
 
         if output is not None:
             match_list = []

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -237,7 +237,7 @@ class P4:
         if cl_number:
             p4_reconcile_args.extend(['-c', cl_number])
         if workspace_path_to_reconcile:
-            if not workspace_path_to_reconcile.endswith('...'):
+            if os.path.isdir(workspace_path_to_reconcile) or workspace_path_to_reconcile.endswith(('/', '\\')):
                 workspace_path_to_reconcile = os.path.join(workspace_path_to_reconcile, '...')
             workspace_path_to_reconcile = nimp.system.sanitize_path(workspace_path_to_reconcile)
             p4_reconcile_args.append(workspace_path_to_reconcile)

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -282,7 +282,7 @@ class P4:
     @staticmethod
     def parse_json_output_for_data(output):
         data = ''
-        output = [json_element for json_element in output.split('\n') if json_element]
+        output = [json_element for json_element in output.splitlines() if json_element]
         for output_chunk in output:
             output_chunk = json.loads(output_chunk)
             if 'data' in output_chunk.keys():

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -405,17 +405,18 @@ class P4:
 
     def _update_cl_spec_field(self, cl_spec, spec_field, field_content):
         assert spec_field in ALL_SPEC_FIELDS
-        possible_following_fields = r":\r\n|".join(ALL_SPEC_FIELDS)
-        # using dotall flag rather than multiline, that stops at first encountered \r\n
-        pattern = re.compile(rf'{spec_field}:\r\n\t(.*)\r\n\r\n({possible_following_fields}:\r\n)', re.DOTALL)
+        possible_following_fields = fr":{os.linesep}|".join(ALL_SPEC_FIELDS) + fr':{os.linesep}'
+        pattern = re.compile(rf'{spec_field}:{os.linesep}\t(.*){os.linesep}{os.linesep}({possible_following_fields})',
+                             # using dotall flag rather than multiline, that stops at first encountered \r\n
+                             re.DOTALL)
         matches = re.findall(pattern, cl_spec)
         if not matches:
             # It's possible that there is no following field
-            pattern = re.compile(rf'{spec_field}:\r\n\t(.*)(\r\n\r\n)', re.DOTALL)
+            pattern = re.compile(rf'{spec_field}:{os.linesep}\t(.*)({os.linesep}{os.linesep})', re.DOTALL)
             matches = re.findall(pattern, cl_spec)
         assert len(matches) == 1
         initial_desc, following_field = matches[0]
-        return re.sub(pattern, f'{spec_field}:\r\n\t{field_content}\r\n\r\n{following_field}', cl_spec)
+        return re.sub(pattern, f'{spec_field}:{os.linesep}\t{field_content}{os.linesep}{os.linesep}{following_field}', cl_spec)
 
     def submit(self, cl_number=None, description=None):
         ''' submit from default if no cl_number is provided

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -242,9 +242,7 @@ class P4:
             workspace_path_to_reconcile = nimp.system.sanitize_path(workspace_path_to_reconcile)
             p4_reconcile_args.append(workspace_path_to_reconcile)
 
-        if self._run(*p4_reconcile_args) is None:
-            return False
-        return True
+        return self._run(*p4_reconcile_args) is None
 
     def get_changelist_description(self, cl_number):
         ''' Returns description of given changelist '''
@@ -268,15 +266,11 @@ class P4:
 
     def get_file_workspace_current_revision(self, file):
         ''' Returns the file revision currently synced in the workspace '''
-        try:
-            revision, = next(self._parse_command_output(['have', file], r'\.\.\. haveRev (\d+)'))
-        except StopIteration as e:
-            revision = None
-        return revision
+        return next(self._parse_command_output(['have', file], r'\.\.\. haveRev (\d+)'), default=None)
 
     def print(self, p4_print_command_args):
         ''' wrapper for p4 print command '''
-        output = self._run('print', f'{p4_print_command_args}', use_json_format=True)
+        output = self._run('print', p4_print_command_args, use_json_format=True)
         return self.parse_json_output_for_data(output)
 
     @staticmethod
@@ -285,7 +279,7 @@ class P4:
         output = [json_element for json_element in output.splitlines() if json_element]
         for output_chunk in output:
             output_chunk = json.loads(output_chunk)
-            if 'data' in output_chunk.keys():
+            if 'data' in output_chunk:
                 data += output_chunk['data']
         return data
 

--- a/nimp/utils/p4.py
+++ b/nimp/utils/p4.py
@@ -270,15 +270,15 @@ class P4:
         ''' Returns the file revision currently synced in the workspace '''
         return next(self._parse_command_output(['have', file], r'\.\.\. haveRev (\d+)'), default=None)
 
-    def print(self, p4_print_command_args):
+    def print_file_data(self, file, revision=None):
         ''' wrapper for p4 print command '''
-        data = ''
-        output = self._run('print', p4_print_command_args, use_json_format=True, hide_output=True)
-        output = [json_element for json_element in output.splitlines() if json_element]
+        revision = f"#{revision}" if revision is not None else ''
+        data = None
+        output = self._run('print', file+revision, use_json_format=True, hide_output=False)
+        output = [json.loads(json_element) for json_element in output.splitlines() if json_element]
         for output_chunk in output:
-            output_chunk = json.loads(output_chunk)
             if 'data' in output_chunk:
-                data += output_chunk['data']
+                data = output_chunk['data']
         return data
 
     def get_or_create_changelist(self, description):


### PR DESCRIPTION
Simple json output support for p4 commands.
A few handful functions:
- reconcile current workspace in default cl
- submit current default cl
- get a file current revision in the workspace
- print file content by revision