### PR TITLE
Create-loadlist: add slicing and get all p4 files

### DIFF
--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -41,10 +41,10 @@ class CreateLoadlist(nimp.command.Command):
 		return env.is_unreal, ''
 
 	def sanitized_changelists(self, env):
-		changelists = []
+		changelists = set()
 		# deal with possible nimp create-loadlist changelists '12 23 43' "23"
-		for possible_cl_streak_string in env.changelists[1:]:
-			changelists += re.sub(' +', ';', possible_cl_streak_string).split(';')
+		for possible_cl_streak_string in env.changelists:
+			changelists.update(re.sub(' +', ';', possible_cl_streak_string).split(';'))
 		return [cl for cl in changelists if cl]
 
 	def get_modified_files(self, env):

--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -91,23 +91,26 @@ class CreateLoadlist(nimp.command.Command):
 
 		return modified_files
 
-
 	def run(self, env):
+		loadlist_path = self.setup_loadlist_path(env)
 		loadlist_files = self.get_modified_files(env, env.extensions)
-
-		loadlist_path = env.output if env.output else f'{env.unreal_loadlist}'
-		loadlist_path = os.path.abspath(env.format(nimp.system.sanitize_path(loadlist_path)))
-
 		if env.check_empty:
 			return self.check_empty_loadlist(loadlist_files)
-
-		if not env.dry_run:
-			with open(loadlist_path, 'w') as fp:
-				for file in loadlist_files:
-					print(file)
-					fp.write(f'{file}\n')
+		self.write_and_display_loadlist(env, loadlist_path, loadlist_files)
 
 		return True
+
+	def setup_loadlist_path(self, env):
+		loadlist_path = env.output if env.output else f'{env.unreal_loadlist}'
+		loadlist_path = os.path.abspath(env.format(nimp.system.sanitize_path(loadlist_path)))
+		return loadlist_path
+
+	def write_and_display_loadlist(self, env, loadlist_path, modified_files):
+		if not env.dry_run:
+			with open(loadlist_path, 'w') as output:
+				for file in modified_files:
+					print(file)
+					output.write(f'{file}\n')
 
 	def check_empty_loadlist(self, modified_files):
 		results = {'loadlist_is_empty': True}

--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -36,6 +36,7 @@ class CreateLoadlist(nimp.command.Command):
 		parser.add_argument('-o', '--output', help = 'output file')
 		parser.add_argument('-e', '--extensions', nargs = argparse.ZERO_OR_MORE, help = 'file extensions to include', default = [ 'uasset', 'umap' ])
 		parser.add_argument('--check-empty', action = 'store_true', help = 'Returns check empty in json format')
+		parser.add_argument('--clean', action='store_true', help='Loadlist cleanup')
 		nimp.utils.p4.add_arguments(parser)
 		nimp.command.add_common_arguments(parser, 'dry_run', 'slice_job')
 		return True
@@ -93,6 +94,8 @@ class CreateLoadlist(nimp.command.Command):
 
 	def run(self, env):
 		loadlist_path = self.setup_loadlist_path(env)
+		if env.clean:
+			nimp.system.try_remove(loadlist_path, dry_run=env.dry_run)
 		loadlist_files = self.get_modified_files(env, env.extensions)
 		if env.check_empty:
 			return self.check_empty_loadlist(loadlist_files)

--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -22,9 +22,11 @@
 import json
 import os
 import re
+from pathlib import Path
 
 import nimp.command
 import nimp.utils.p4
+
 
 class CreateLoadlist(nimp.command.Command):
 	''' Generates a list of modified files from a set of Perforce changelists '''
@@ -77,11 +79,8 @@ class CreateLoadlist(nimp.command.Command):
 	def run(self, env):
 		loadlist_files = []
 		for filepath in self.get_modified_files(env):
-			file = os.path.basename(filepath)
-			for extension in env.extensions:
-				if file.endswith(extension):
-					loadlist_files.append(file)
-					break
+			if f".{Path(filepath).suffix}" in env.extensions:
+				loadlist_files.append(file)
 
 		loadlist_path = env.output if env.output else f'{env.unreal_loadlist}'
 		loadlist_path = os.path.abspath(env.format(nimp.system.sanitize_path(loadlist_path)))

--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -109,13 +109,11 @@ class CreateLoadlist(nimp.command.Command):
 		if env.check_empty:
 			return self.check_empty_loadlist(loadlist_files)
 
-		with open(env.format(loadlist_path), 'w+') as output:
-			lines = output.readlines()
-			for file in loadlist_files:
-				if file not in lines:
+		if not env.dry_run:
+			with open(loadlist_path, 'w') as fp:
+				for file in loadlist_files:
 					print(file)
-					if not env.dry_run:
-						output.write(f'{file}\n')
+					fp.write(f'{file}\n')
 
 		return True
 

--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -37,6 +37,7 @@ class CreateLoadlist(nimp.command.Command):
 		parser.add_argument('-e', '--extensions', nargs = argparse.ZERO_OR_MORE, help = 'file extensions to include', default = [ 'uasset', 'umap' ])
 		parser.add_argument('--check-empty', action = 'store_true', help = 'Returns check empty in json format')
 		nimp.utils.p4.add_arguments(parser)
+		nimp.command.add_common_arguments(parser, 'dry_run')
 		return True
 
 	def is_available(self, env):
@@ -98,7 +99,8 @@ class CreateLoadlist(nimp.command.Command):
 			for file in loadlist_files:
 				if file not in lines:
 					print(file)
-					output.write(f'{file}\n')
+					if not env.dry_run:
+						output.write(f'{file}\n')
 
 		return True
 

--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -32,7 +32,7 @@ class CreateLoadlist(nimp.command.Command):
 	''' Generates a list of modified files from a set of Perforce changelists '''
 
 	def configure_arguments(self, env, parser):
-		parser.add_argument('changelists', nargs = argparse.ZERO_OR_MORE, help = 'select the changelists to list files from. Defaults to listing all files in havelist')
+		parser.add_argument('changelists', nargs = argparse.ZERO_OR_MORE, help = 'select the changelists to list files from. Defaults to listing all files in havelist', default=[])
 		parser.add_argument('-o', '--output', help = 'output file')
 		parser.add_argument('-e', '--extensions', nargs = argparse.ZERO_OR_MORE, help = 'file extensions to include', default = [ 'uasset', 'umap' ])
 		parser.add_argument('--check-empty', action = 'store_true', help = 'Returns check empty in json format')
@@ -43,15 +43,7 @@ class CreateLoadlist(nimp.command.Command):
 	def is_available(self, env):
 		return env.is_unreal, ''
 
-	def sanitized_changelists(self, env):
-		changelists = set()
-		# deal with possible nimp create-loadlist changelists '12 23 43' "23"
-		for possible_cl_streak_string in env.changelists:
-			changelists.update(re.sub(' +', ';', possible_cl_streak_string).split(';'))
-		return [cl for cl in changelists if cl]
-
 	def get_modified_files(self, env, extensions):
-		changelists = self.sanitized_changelists(env)
 		p4 = nimp.utils.p4.get_client(env)
 
 		# Do not use '//...' which will also list files not mapped to workspace
@@ -63,7 +55,7 @@ class CreateLoadlist(nimp.command.Command):
 		if len(paths) <= 0:
 			paths.append(root)
 
-		changelists = [f'@{cl}' for cl in changelists]
+		changelists = [f'@{cl}' for cl in env.changelists]
 		if len(changelists) <= 0:
 			changelists = ['#have']
 


### PR DESCRIPTION
It's now possible to:
- clean previous loadlist with the addition of the --clean param
- split loadlists into slices and only dispay selected one
- get all workspace files from --root param when there is no changelist

i.e.
nimp create-loadlist changelists --clean --p4client <...> --root "Content/..." --slice-job-count 20 --slice-job-index 19 ==> will create and dispaly the 19th slice of the whole workspace files startign from "Content/...".