### PR TITLE
{WIP} Introduce commandlet variants

### DIFF
--- a/nimp/base_commands/run.py
+++ b/nimp/base_commands/run.py
@@ -85,6 +85,11 @@ class _Commandlet(RunCommand):
         super().configure_arguments(env, parser)
         nimp.command.add_common_arguments(parser, 'slice_job')
         nimp.utils.p4.add_arguments(parser)
+        parser.add_argument('-v',
+                            '--variant',
+                            help='Select a command variant',
+                            default=None,
+                            metavar='<variant>')
 
     def __init__(self):
         super(_Commandlet, self).__init__()
@@ -93,7 +98,15 @@ class _Commandlet(RunCommand):
         if not nimp.unreal.is_unreal_available(env):
             logging.error('Not an Unreal Engine project')
             return False
-        args = env.parameters + nimp.unreal.get_args_for_commandlet(env)
+
+        args = []
+        if hasattr(env, 'default_parameters') and env.default_parameters:
+            args.extend(env.default_parameters)
+        args += env.parameters + nimp.unreal.get_args_for_commandlet(env)
+        if env.variant:
+            if hasattr(env, env.variant) and getattr(env, env.variant) is not None:
+                args.extend(getattr(env, env.variant))
+
         return nimp.unreal.commandlet(env, env.command_name, *[env.format(arg) for arg in args])
 
 


### PR DESCRIPTION
This is a WIP starting point to think about one commandlet having several variants used in ci.
- We could make one config file each time with a prefix/suffix and call it through ci (.DNECommandletWhatever-1.conf, etc..), into a folder or a root. 
- This approach lets use use one config file only to call several variants from the same commandlet.

This is to be viewed with the config pull request on our gitea.

User_config params can now have:
- default parameters
- and a variant called by --variant my_variant