### PR TITLE
create-loadlists: add dirs and exclude-dirs params

### DIFF
--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -37,7 +37,7 @@ class CreateLoadlist(nimp.command.Command):
 		parser.add_argument('changelists', nargs = argparse.ZERO_OR_MORE, help = 'select the changelists to list files from. Defaults to listing all files in havelist', default=[])
 		parser.add_argument('-o', '--output', help = 'output file')
 		parser.add_argument('-e', '--extensions', nargs = argparse.ZERO_OR_MORE, help = 'file extensions to include', default = [ 'uasset', 'umap' ])
-		parser.add_argument('--dirs', nargs = argparse.ZERO_OR_MORE, help = 'directories to include', default = None)
+		parser.add_argument('--dirs', nargs = argparse.ZERO_OR_MORE, help = 'directories to include', default = ['//{p4client}/...'])
 		parser.add_argument('--exclude-dirs', nargs = argparse.ZERO_OR_MORE, help = 'directories to exclude', default = None)
 		parser.add_argument('--check-empty', action = 'store_true', help = 'Returns check empty in json format')
 		nimp.utils.p4.add_arguments(parser)
@@ -80,14 +80,9 @@ class CreateLoadlist(nimp.command.Command):
 	def get_modified_files(self, env, extensions):
 		p4 = nimp.utils.p4.get_client(env)
 
-		# Do not use '//...' which will also list files not mapped to workspace
-		root = f"//{p4._client}/..."
-
 		paths = []
 		for dir, ext in self._product_dirs_and_extensions(env, extensions):
-			paths.append(f"{root}{dir}{ext}")
-		if len(paths) <= 0:
-			paths.append(root)
+			paths.append(f"{dir}{ext}")
 
 		filespecs = []
 		for path, cl in self._product_paths_and_changelists(env, paths):

--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -51,7 +51,8 @@ class CreateLoadlist(nimp.command.Command):
 	def _product_dirs_and_extensions(env, extensions):
 		if env.dirs is None:
 			env.dirs = ['']
-		return list(itertools.product(env.dirs, extensions))
+		dirs = [env.format(dir) for dir in env.dirs]
+		return list(itertools.product(dirs, extensions))
 
 	@staticmethod
 	def _product_paths_and_changelists(env, paths):

--- a/nimp/base_commands/create_loadlist.py
+++ b/nimp/base_commands/create_loadlist.py
@@ -53,8 +53,13 @@ class CreateLoadlist(nimp.command.Command):
 		return list(itertools.product(env.dirs, extensions))
 
 	@staticmethod
-	def _exclude_from_modified_files(env, filepath):
-		if env.exclude_dirs is None:
+	def _product_paths_and_changelists(env, paths):
+		changelists = [f'@{cl}' for cl in env.changelists]
+		if len(changelists) <= 0:
+			changelists = ['#have']
+		return list(itertools.product(paths, changelists))
+
+
 			return False
 		for exclude_dir in env.exclude_dirs:
 			if os.path.normpath(exclude_dir) in filepath:
@@ -72,14 +77,9 @@ class CreateLoadlist(nimp.command.Command):
 		if len(paths) <= 0:
 			paths.append(root)
 
-		changelists = [f'@{cl}' for cl in env.changelists]
-		if len(changelists) <= 0:
-			changelists = ['#have']
-
 		filespecs = []
-		for cl in changelists:
-			for path in paths:
-				filespecs.append(f"{path}{cl}")
+		for path, cl in self._product_paths_and_changelists(env, paths):
+			filespecs.append(f"{path}{cl}")
 
 		base_command = [
 			"fstat",


### PR DESCRIPTION
--dirs lets us include only dirs we want from the workspace --exclude-dirs lets us scrap files we do not want from included stuff

i.e.
nimp create-loadlist --dirs Game/Content/... --exclude-dirs ExcludeThatDir AndThatOneAlso