### PR TITLE
Package: Change the way we update active write revisions ini files

### DIFF
--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -455,12 +455,12 @@ class Package(nimp.command.Command):
                     for key in keys:
                         sanitized_ini = [line for index, line in enumerate(sanitized_ini) if
                                          index not in section_range or
-                                         index in section_range and not re.match(rf'^{key}=(.*?)$', line)]
+                                         (index in section_range and not re.match(rf'^{key}=(.*?)$', line))]
                 else:
                     for key in keys:
                         sanitized_ini = [line for index, line in enumerate(sanitized_ini) if
                                          index <= section_index or
-                                         index > section_index and re.match(rf'^{key}=(.*?)$', line)]
+                                         (index > section_index and not re.match(rf'^{key}=(.*?)$', line))]
 
             if not section_indexes:  # Insert section on top if it doesn't exist
                 sanitized_ini.insert(0, '')

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -444,11 +444,11 @@ class Package(nimp.command.Command):
             sanitized_ini = ini_content.splitlines()
             section_index = _find_section_indexes(sanitized_ini, section)
 
-            # section exists, wipe existing keys from ini content withing section bounds
+            # section exists, wipe existing keys from ini content within section bounds
             if section_index is not None:
                 next_section_index = _find_section_indexes(sanitized_ini[section_index+1:], '.*')
-                section_end = section_index + next_section_index if next_section_index is not None else len(sanitized_ini)
-                section_range = list(range(section_index, section_end+1))
+                section_end = (section_index + next_section_index + 1) if next_section_index is not None else len(sanitized_ini)
+                section_range = list(range(section_index, section_end))
                 for key in keys:
                     sanitized_ini = [line for index, line in enumerate(sanitized_ini) if
                                      index not in section_range or

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -441,24 +441,17 @@ class Package(nimp.command.Command):
             if not keys:
                 return
 
-            # wipe existing keys from ini content withing section bounds
-            # look for section index
             sanitized_ini = ini_content.splitlines()
+            # wipe existing keys from ini content withing section bounds
             section_index = _find_section_indexes(sanitized_ini, section)
-
             if section_index is not None:
                 next_section_index = _find_section_indexes(sanitized_ini[section_index+1:], '.*')
-                if next_section_index is not None:
-                    section_range = list(range(section_index, section_index + next_section_index + 1))
-                    for key in keys:
-                        sanitized_ini = [line for index, line in enumerate(sanitized_ini) if
-                                         index not in section_range or
-                                         (index in section_range and not re.match(rf'^{key}=(.*?)$', line))]
-                else:
-                    for key in keys:
-                        sanitized_ini = [line for index, line in enumerate(sanitized_ini) if
-                                         index <= section_index or
-                                         (index > section_index and not re.match(rf'^{key}=(.*?)$', line))]
+                section_end = section_index + next_section_index if next_section_index is not None else len(sanitized_ini)
+                section_range = list(range(section_index, section_end+1))
+                for key in keys:
+                    sanitized_ini = [line for index, line in enumerate(sanitized_ini) if
+                                     index not in section_range or
+                                     (index in section_range and not re.match(rf'^{key}=(.*?)$', line))]
 
             if section_index is None:  # Insert section on top if it doesn't exist
                 sanitized_ini.insert(0, '')

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -442,8 +442,9 @@ class Package(nimp.command.Command):
                 return
 
             sanitized_ini = ini_content.splitlines()
-            # wipe existing keys from ini content withing section bounds
             section_index = _find_section_indexes(sanitized_ini, section)
+
+            # section exists, wipe existing keys from ini content withing section bounds
             if section_index is not None:
                 next_section_index = _find_section_indexes(sanitized_ini[section_index+1:], '.*')
                 section_end = section_index + next_section_index if next_section_index is not None else len(sanitized_ini)
@@ -452,12 +453,14 @@ class Package(nimp.command.Command):
                     sanitized_ini = [line for index, line in enumerate(sanitized_ini) if
                                      index not in section_range or
                                      (index in section_range and not re.match(rf'^{key}=(.*?)$', line))]
-
-            if section_index is None:  # Insert section on top if it doesn't exist
+            # Section doesn't exist, insert section on top of ini file
+            else:
                 sanitized_ini.insert(0, '')
                 sanitized_ini.insert(0, f'[{section}]')
                 section_index = 0
-            for key in keys:  # Insert keys at the top of the section
+
+            # add keys to section
+            for key in keys:
                 sanitized_ini.insert(section_index + 1, f'{key}={ini_parser[section][key]}')
 
             return '\n'.join(sanitized_ini)


### PR DESCRIPTION
Python ue config parsers doesn't handle section with multiple section keys like:
+maps=path/to/map1
+maps=path/to/map2
... and just flattens to one key with last value encountered like: +maps=path/to/map2

This is an attempt to make minimal to no changes to how we compute dne revisions.
We don't save our computed ini config parser into a file Just take what we have and use a helper function that will update only the dne revisions inside the existing ini file