### PR TITLE
Lca/xsx encryption

### DIFF
--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -147,7 +147,6 @@ class UnrealPackageConfiguration():
         self.ignored_warnings = []
         self.is_final_submission = False
         self.for_distribution = False
-        self.xsx_encryption_file = None
         self.no_compile_packaging = False
 
         self.msixvc = False
@@ -251,7 +250,6 @@ class Package(nimp.command.Command):
         package_configuration.msixvc = env.msixvc or env.platform == 'xboxone'
         package_configuration.is_final_submission = env.final
         package_configuration.for_distribution = self.set_for_distribution_from_config_files(env)
-        package_configuration.xsx_encryption_file = env.xsx_encryption_file
 
         package_configuration.package_tool_path = platform_desc.package_tool_path
         package_configuration.layout_file_extension = env.layout_file_extension
@@ -1240,6 +1238,30 @@ class Package(nimp.command.Command):
         package_configuration.extra_options.append('-NoGameOs')
 
     @staticmethod
+    def setup_xsx_lekb_encryption_file(env):
+        encryption_file = None
+        is_default_xsx_encryption = True
+        if getattr(env, 'xsx_encryption_file') is not None:
+            conf_encryption_file = nimp.system.sanitize_path(env.format(env.xsx_encryption_file))
+            conf_encryption_file = os.path.abspath(conf_encryption_file)
+            if os.path.exists(conf_encryption_file):
+                logging.debug("Encryption file %s found" % conf_encryption_file)
+                encryption_file = conf_encryption_file
+                is_default_xsx_encryption = False
+            else:
+                logging.error("Encryption file %s not found" % conf_encryption_file)
+        if is_default_xsx_encryption:
+            default_encryption_message_warning = "\n".join([
+                "This package will be released with default encryption scheme, this is not secure.",
+                "It is recommend that you use a LEKB key, secure and testable at the same time.",
+                "You can add xsx_encryption_file to nimp project conf.",
+                "More info on how to generate a valid key:",
+                "https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/packaging/title-packaging-streaming-install-testing#encryption"
+            ])
+            logging.warning(default_encryption_message_warning)
+        return encryption_file
+
+    @staticmethod
     def package_with_uat(env, package_configuration):
         if package_configuration.target_platform == 'PS5' and env.dlc:
             Package.configure_packaging_for_ps5_dlc(env, package_configuration)
@@ -1260,25 +1282,10 @@ class Package(nimp.command.Command):
 
             if package_configuration.for_distribution:
                 package_command.append('-distribution')
-                is_default_xsx_encryption = True
-                if getattr(env, 'xsx_encryption_file') is not None:
-                    encryption_file = nimp.system.sanitize_path(env.format(env.xsx_encryption_file))
-                    encryption_file = os.path.abspath(encryption_file)
-                    if os.path.exists(encryption_file):
-                        package_command.append(f'-packageencryptionkeyfile={encryption_file}')
-                        logging.debug("Encryption file %s will be used" % encryption_file)
-                        is_default_xsx_encryption = False
-                    else:
-                        logging.error("Encryption file %s not found." % encryption_file)
-                if is_default_xsx_encryption:
-                    default_encryption_message_warning = "\n".join([
-                        "This package will be released with default encryption scheme, this is not secure.",
-                        "It is recommend that you use a LEKB key, secure and testable at the same time.",
-                        "You can add xsx_encryption_file to nimp project conf.",
-                        "More info on how to generate a valid key:",
-                        "https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/packaging/title-packaging-streaming-install-testing#encryption"
-                    ])
-                    logging.warning(default_encryption_message_warning)
+                if env.is_xsx:
+                    xsx_encryption_file = Package.setup_xsx_lekb_encryption_file(env)
+                    if xsx_encryption_file is not None:
+                        package_command.append(f'-packageencryptionkeyfile={xsx_encryption_file}')
 
             if not hasattr(env, 'skip_pkg_utf8_output') or not env.skip_pkg_utf8_output:
                 package_command += ['-UTF8Output']

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -1261,7 +1261,7 @@ class Package(nimp.command.Command):
             if package_configuration.for_distribution:
                 package_command.append('-distribution')
                 is_default_encryption_scheme = True
-                if hasattr(env, 'xsx_encryption_file') and env.xsx_encryption_file is not None:
+                if getattr(env, 'xsx_encryption_file') is not None:
                     encryption_file = nimp.system.sanitize_path(env.format(env.xsx_encryption_file))
                     encryption_file = os.path.abspath(encryption_file)
                     if os.path.exists(encryption_file):

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -1258,7 +1258,6 @@ class Package(nimp.command.Command):
             ]
             package_command.extend(nimp.unreal.get_p4_args_for_commandlet(env))
 
-            package_configuration.for_distribution = True
             if package_configuration.for_distribution:
                 package_command.append('-distribution')
                 if env.xsx_encryption_file is not None:
@@ -1272,8 +1271,8 @@ class Package(nimp.command.Command):
             if not hasattr(env, 'skip_pkg_utf8_output') or not env.skip_pkg_utf8_output:
                 package_command += ['-UTF8Output']
 
-            # if package_configuration.no_compile_packaging:
-            #     package_command += [ '-NoCompile' ]
+            if package_configuration.no_compile_packaging:
+                package_command += [ '-NoCompile' ]
 
             for option in package_configuration.extra_options:
                 package_command += shlex.split(option)

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -1266,7 +1266,7 @@ class Package(nimp.command.Command):
                     encryption_file = os.path.abspath(encryption_file)
                     if os.path.exists(encryption_file):
                         is_default_encryption_scheme = False
-                        package_command.append(f'-packageencryptionkeyfile="{encryption_file}"')
+                        package_command.append(f'-packageencryptionkeyfile={encryption_file}')
                         logging.debug("Encryption file %s will be used" % encryption_file)
                     else:
                         logging.warning("Encryption file not found, will use default encryption scheme")

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -1261,7 +1261,7 @@ class Package(nimp.command.Command):
             if package_configuration.for_distribution:
                 package_command.append('-distribution')
                 is_default_encryption_scheme = True
-                if env.xsx_encryption_file is not None:
+                if hasattr(env, 'xsx_encryption_file') and env.xsx_encryption_file is not None:
                     encryption_file = nimp.system.sanitize_path(env.format(env.xsx_encryption_file))
                     encryption_file = os.path.abspath(encryption_file)
                     if os.path.exists(encryption_file):
@@ -1273,8 +1273,8 @@ class Package(nimp.command.Command):
                 if is_default_encryption_scheme:
                     default_encryption_message_warning = "\n".join([
                         "This package will be released with default encryption scheme, this is not secure.",
-                        "It is recommend that you use a LEKB key, secure and testable at the same time",
-                        "You can pass the following nimp arg --encryption-file <path_to_key_file>",
+                        "It is recommend that you use a LEKB key, secure and testable at the same time.",
+                        "You can add xsx_encryption_file to nimp project conf.",
                         "More info on how to generate a valid key:",
                         "https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/packaging/title-packaging-streaming-install-testing#encryption"
                     ])

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -1260,13 +1260,25 @@ class Package(nimp.command.Command):
 
             if package_configuration.for_distribution:
                 package_command.append('-distribution')
+                is_default_encryption_scheme = True
                 if env.xsx_encryption_file is not None:
                     encryption_file = nimp.system.sanitize_path(env.format(env.xsx_encryption_file))
                     encryption_file = os.path.abspath(encryption_file)
                     if os.path.exists(encryption_file):
+                        is_default_encryption_scheme = False
                         package_command.append(f'-packageencryptionkeyfile="{encryption_file}"')
+                        logging.debug("Encryption file %s will be used" % encryption_file)
                     else:
                         logging.warning("Encryption file not found, will use default encryption scheme")
+                if is_default_encryption_scheme:
+                    default_encryption_message_warning = "\n".join([
+                        "This package will be released with default encryption scheme, this is not secure.",
+                        "It is recommend that you use a LEKB key, secure and testable at the same time",
+                        "You can pass the following nimp arg --encryption-file <path_to_key_file>",
+                        "More info on how to generate a valid key:",
+                        "https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/packaging/title-packaging-streaming-install-testing#encryption"
+                    ])
+                    logging.warning(default_encryption_message_warning)
 
             if not hasattr(env, 'skip_pkg_utf8_output') or not env.skip_pkg_utf8_output:
                 package_command += ['-UTF8Output']

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -1260,17 +1260,17 @@ class Package(nimp.command.Command):
 
             if package_configuration.for_distribution:
                 package_command.append('-distribution')
-                is_default_encryption_scheme = True
+                is_default_xsx_encryption = True
                 if getattr(env, 'xsx_encryption_file') is not None:
                     encryption_file = nimp.system.sanitize_path(env.format(env.xsx_encryption_file))
                     encryption_file = os.path.abspath(encryption_file)
                     if os.path.exists(encryption_file):
-                        is_default_encryption_scheme = False
                         package_command.append(f'-packageencryptionkeyfile={encryption_file}')
                         logging.debug("Encryption file %s will be used" % encryption_file)
+                        is_default_xsx_encryption = False
                     else:
-                        logging.warning("Encryption file not found, will use default encryption scheme")
-                if is_default_encryption_scheme:
+                        logging.error("Encryption file %s not found." % encryption_file)
+                if is_default_xsx_encryption:
                     default_encryption_message_warning = "\n".join([
                         "This package will be released with default encryption scheme, this is not secure.",
                         "It is recommend that you use a LEKB key, secure and testable at the same time.",

--- a/nimp/base_commands/package.py
+++ b/nimp/base_commands/package.py
@@ -251,7 +251,7 @@ class Package(nimp.command.Command):
         package_configuration.msixvc = env.msixvc or env.platform == 'xboxone'
         package_configuration.is_final_submission = env.final
         package_configuration.for_distribution = self.set_for_distribution_from_config_files(env)
-        package_configuration.xsx_eption_file = env.xsx_encryption_file
+        package_configuration.xsx_encryption_file = env.xsx_encryption_file
 
         package_configuration.package_tool_path = platform_desc.package_tool_path
         package_configuration.layout_file_extension = env.layout_file_extension


### PR DESCRIPTION
First attempt a implementing xsx /lk encryption.
Needs conf to have the following:
`"xsx_encryption_file": "{uproject_dir}/Config/XSX/project.lekb",` (or anywhere really, it doesn't matter)

lekb file is supposed to be a sensitive file with restricted access rights.
The cekb file ouput by the process is also sensitive stuff.

I've built a key and a package with it using this method, QA tested it and told me it installed and worked just fine (as long as the cekb file is in there with the build).

I'm unsure specifying a path in the project conf is the way to go but am sharing this as a start so we can think about this and carry on with modifications if needed.

I have looked at UAT's codebase and found no way to specify a path directly in the ini files btw.
Maybe it's rather supposed to look at path specified by the worker through env variable? (and then nothing in the project conf or ue conf) = we're looking into env.get('path_to_lekb', None) and act if we find something?

There's also the question of the LEKB location: Directly on the farms? Perforced?