### PR TITLE
summary: add error pattern for missing actors

### DIFF
--- a/nimp/summary.py
+++ b/nimp/summary.py
@@ -75,6 +75,8 @@ class SummaryHandler(logging.Handler):
             r'The layout contained an invalid chunk\.',
             r'Chunks must contain at least 1 non-empty file\.',
             r'FileGroup .* did not match any files\.',
+            # World partition missing external actors
+            r".*__ExternalActors__.*Can't find file",
         ]
 
         warning_patterns = [


### PR DESCRIPTION
Workaround to avoid silent failure during checks which breaks package.
Needed due to UE5 World Partition missing support on "old" commandlet
```
2024-09-06 17:58:38,508 [INFO] Finished with exit code 0 (0x00000000)
2024-09-06 17:58:38,508 [ERROR] Command succeeded with errors
2024-09-06 17:58:38,511 [INFO] Command took 1664.882923 seconds.
```