### PR TITLE
download-fileset: improve `_find_matching_artifact` for git revision

### DIFF
--- a/nimp/artifacts.py
+++ b/nimp/artifacts.py
@@ -370,19 +370,16 @@ def create_hash(artifact_path: str, hash_method, dry_run: bool) -> None:
 
 def get_file_hash(file_path: StrPathLike, hash_method: str):
     '''helper function to parse potentially big files'''
-    assert getattr(hashlib, hash_method)()
-    hash_lib = getattr(hashlib, hash_method)()
+    hasher = hashlib.new(hash_method)
 
     _BLOCK_SIZE = 65536
 
     with open(file_path, 'rb') as fh:
-        file_buffer = fh.read(_BLOCK_SIZE)
-        while len(file_buffer) > 0:
-            hash_lib.update(file_buffer)
-            file_buffer = fh.read(_BLOCK_SIZE)
-    file_hash = hash_lib.hexdigest()
+        while buffer := fh.read(_BLOCK_SIZE):
+            hasher.update(buffer)
+    file_hash = hasher.hexdigest()
 
-    logging.debug(f"{file_path} {hash_method}: {file_hash}")
+    logging.debug("%s %s: %s", file_path, hash_method, file_hash)
     return file_hash
 
 

--- a/nimp/artifacts.py
+++ b/nimp/artifacts.py
@@ -24,7 +24,6 @@
 
 from __future__ import annotations
 
-import copy
 import datetime
 import hashlib
 import json
@@ -66,7 +65,6 @@ if TYPE_CHECKING:
 
 class Artifact(TypedDict):
     revision: str
-    sortable_revision: str
     uri: str
 
 
@@ -74,7 +72,11 @@ def _is_http_url(string: str) -> bool:
     return re.match(r'^http[s]?:\/\/.*$', string) is not None
 
 
-def list_artifacts(artifact_pattern: str, format_arguments: Mapping[str, Any], api_context) -> list[Artifact]:
+def list_artifacts(
+    artifact_pattern: str,
+    format_arguments: Mapping[str, Any],
+    api_context_: nimp.utils.git.GitApiContext | None,
+) -> list[Artifact]:
     '''List all artifacts and their revision using the provided pattern after formatting'''
 
     artifact_pattern = artifact_pattern.format_map(
@@ -103,17 +105,12 @@ def list_artifacts(artifact_pattern: str, format_arguments: Mapping[str, Any], a
             continue
 
         group_revision = artifact_match.group('revision')
-        sortable_revision = copy.deepcopy(group_revision)
-        if api_context:
-            sortable_revision = nimp.utils.git.get_gitea_commit_timestamp(api_context, group_revision)
-        if sortable_revision is not None:
-            all_artifacts.append(
-                {
-                    'revision': group_revision,
-                    'sortable_revision': sortable_revision,
-                    'uri': file_uri,
-                }
-            )
+        all_artifacts.append(
+            {
+                'revision': group_revision,
+                'uri': file_uri,
+            }
+        )
     return all_artifacts
 
 

--- a/nimp/base_commands/p4.py
+++ b/nimp/base_commands/p4.py
@@ -31,7 +31,7 @@ import nimp.utils.p4
 
 def _is_p4_available():
     if shutil.which('p4') is None:
-        return False, ('p4 executable was not found on your system, check your' 'installation.')
+        return False, ('p4 executable was not found on your system, check your installation.')
     return True, ''
 
 

--- a/nimp/environment.py
+++ b/nimp/environment.py
@@ -226,7 +226,9 @@ class Environment:
                         os.environ[key] = val
                         logging.warning(
                             "Could not interpolate %s. Adding un-interpolated %s=%s to environment",
-                            val, key, val
+                            val,
+                            key,
+                            val,
                         )
 
             if self.command is None:

--- a/nimp/system.py
+++ b/nimp/system.py
@@ -22,6 +22,8 @@
 
 '''System utilities (paths, processes)'''
 
+from __future__ import annotations
+
 import fnmatch
 import importlib
 import json
@@ -31,6 +33,7 @@ import re
 import shutil
 import stat
 import time
+from typing import TYPE_CHECKING
 
 import glob2
 
@@ -38,6 +41,9 @@ import nimp.environment
 import nimp.sys.platform
 import nimp.sys.process
 from nimp.utils.python import iter_plugins_entry_points
+
+if TYPE_CHECKING:
+    from typing import overload
 
 
 def try_import(module_name):
@@ -108,7 +114,16 @@ def standardize_path(path):
     return os.path.normpath(path).replace('\\', '/') if path else path
 
 
-def sanitize_path(path):
+if TYPE_CHECKING:
+
+    @overload
+    def sanitize_path(path: None) -> None: ...
+
+    @overload
+    def sanitize_path(path: str) -> str: ...
+
+
+def sanitize_path(path: str | None) -> str | None:
     '''Performs slash replacement to work on both msys and windows'''
     if path is None:
         return None

--- a/nimp/utils/git.py
+++ b/nimp/utils/git.py
@@ -22,13 +22,24 @@
 
 '''Git utilities'''
 
+from __future__ import annotations
+
 import logging
+import time
+from datetime import datetime
+from datetime import timezone
+from typing import TypedDict
+
 import giteapy
 from giteapy.rest import ApiException
-from datetime import datetime, timezone
-import time
 
 import nimp.sys.process
+
+
+class GitApiContext(TypedDict):
+    instance: giteapy.RepositoryApi
+    repo_owner: str
+    repo_name: str
 
 
 def get_branch():
@@ -96,7 +107,7 @@ def gitea_has_missing_params(env):
     return has_missing_params
 
 
-def check_for_gitea_env(env):
+def check_for_gitea_env(env) -> bool:
     if hasattr(env, 'gitea_branches') and env.branch in env.gitea_branches:
         return True
     if hasattr(env, 'gitea_branch') and env.branch in env.gitea_branch:
@@ -104,9 +115,9 @@ def check_for_gitea_env(env):
     return False
 
 
-def initialize_gitea_api_context(env):
+def initialize_gitea_api_context(env) -> GitApiContext | None:
     if not check_for_gitea_env(env):
-        return False
+        return None
     if gitea_has_missing_params(env):
         raise ValueError("You're missing mandatory gitea params in project conf")
 
@@ -117,7 +128,7 @@ def initialize_gitea_api_context(env):
     return {'instance': api_instance, 'repo_owner': env.gitea_repo_owner, 'repo_name': env.gitea_repo_name}
 
 
-def get_gitea_commit_timestamp(gitea_context, commit_sha):
+def get_gitea_commit_timestamp(gitea_context: GitApiContext, commit_sha: str | None) -> str | None:
     if not commit_sha:
         return None
 


### PR DESCRIPTION
Current code rely a lot on the Giteapy package to query our Gitea instance's API to retrieve commit order used to define which artifact is the newest.

Giteapy instantiation [here](https://github.com/dontnod/nimp/blob/18ee4c72cc1a347f90946d2efa8b6b6f37e699fb/nimp/utils/git.py#L107) check for a "gitea env" with [check_for_gitea_env](https://github.com/dontnod/nimp/blob/18ee4c72cc1a347f90946d2efa8b6b6f37e699fb/nimp/utils/git.py#L99), which itself look if current `env.branch` is in a manually maintained list `project_branches` in the project `.nimp.conf`.

On a new branch, CI jobs fail with `[ERROR] Revision seems to be a git commit hash but missing gitea api information. Please check project_branches in project configuration.`

A quick fix would be to add the branch to the configuration branches, but it's better to remove this unnecessary limitation altogether.

This also add:
 - improvement the logic to use the topological order of the commits instead of their date.
- some fastpath for common `--revision` and `--max-revision` cases.
- some typing