### PR TITLE
Check: fix unsafe _json_serialize function

### DIFF
--- a/nimp/base_commands/check.py
+++ b/nimp/base_commands/check.py
@@ -122,7 +122,9 @@ class _Status(CheckCommand):
             return f'<command {o.__class__.__name__}>'
         if isinstance(o, nimp.sys.platform.Platform):
             return f'<platform {o.__name__}>'
-        return o.__dict__
+        if hasattr(o, "__dict__"):
+            return o.__dict__
+        return str(o)
 
     @staticmethod
     def _show_user_environment():


### PR DESCRIPTION
Some python objects don't have a __dict__ as evidenced by 0.26 latest version of package.version.Verssion() object.